### PR TITLE
Fixed 400 Discord Response on bad URL

### DIFF
--- a/src/main/groovy/Scraper/Models/Player.groovy
+++ b/src/main/groovy/Scraper/Models/Player.groovy
@@ -5,6 +5,7 @@ class Player {
   String server
   String serverSlug
   String playerClass
+  String spec
   String battleTag
   String avatarUrl
   String specIconUrl
@@ -32,10 +33,6 @@ class Player {
 
   String getServerCode() {
     (server.trim().toLowerCase()).replaceAll(" ", "-").replaceAll("'", "")
-  }
-
-  String getSpec() {
-    return ((specIconUrl =~ /^.*[\\|\/](.+?)\.[^\.]+$/)[0][1]).split('-')[1]
   }
 
   void setServer(String server) {

--- a/src/main/groovy/Scraper/WCL/WCLRequest.groovy
+++ b/src/main/groovy/Scraper/WCL/WCLRequest.groovy
@@ -21,7 +21,7 @@ import java.text.DecimalFormat
 @Slf4j
 abstract class WCLRequest {
   private String api_uri = "https://www.warcraftlogs.com"
-  private String avatar_uri = "https://assets.rpglogs.com/img/warcraft/icons"
+  private String icon_uri = "https://assets.rpglogs.com/img/warcraft/icons"
   private httpClient = HttpUtil.httpClient()
   private String accessToken
 
@@ -73,8 +73,10 @@ abstract class WCLRequest {
     player.setServer(characterData["realm"]["name"] as String)
     player.setServerSlug(characterData["realm"]["slug"] as String)
     player.setPlayerClass(characterData["character_class"]["name"] as String)
-    def urlClass = player.getPlayerClass().toLowerCase().replaceAll(" ", "")
-    player.setSpecIconUrl("$avatar_uri/${urlClass}-${characterData["active_spec"]["name"]}.jpg")
+    player.setSpec(characterData["active_spec"]["name"] as String)
+    def urlClass = player.getPlayerClass().toLowerCase().replaceAll(" ", new String())
+    def urlSpec = player.getSpec().toLowerCase().replaceAll(" ", new String())
+    player.setSpecIconUrl("$icon_uri/$urlClass-${urlSpec}.jpg")
     player.setClassColor(ClassColors.get(player.getPlayerClass().toLowerCase()))
     if (zoneRankings["difficulty"] == 5) {
       int prog = 0


### PR DESCRIPTION
there was a problem where specs that have names such as Beast Mastery would break the link to the player spec because of the space. I've fixed this in the WCLRequest class where it creates the link to the player spec image.

closes 3