### PR TITLE
Return null instead of throwing uncaught exception

### DIFF
--- a/src/main/groovy/Scraper/WCL/WCLRequest.groovy
+++ b/src/main/groovy/Scraper/WCL/WCLRequest.groovy
@@ -53,7 +53,8 @@ abstract class WCLRequest {
     EntityUtils.consume(response.getEntity())
 
     if (responseCode != 200) {
-      throw new Exception("Warcraftlogs responded with a non-200 status code.")
+      log.error("Warcraftlogs responded with a non-200 status code while accessing character ${playerName}-${serverName}")
+      return null
     }
 
     if (!responseObject["data"]["player"]["character"]) {


### PR DESCRIPTION
when a non-200 response is returned, return null and log error message. Player is not processed when null is returned from the player update method.

closes #14 