### PR TITLE
Improvements/11 rate limiting

### DIFF
--- a/src/main/groovy/Scraper/ScrapeResource.groovy
+++ b/src/main/groovy/Scraper/ScrapeResource.groovy
@@ -167,6 +167,7 @@ class ScrapeResource {
         log.info("Player $player.name unable to post to discord. (Timeout)")
         return
       }
+      Thread.sleep(500)
     }
 
     database.closeConnection()


### PR DESCRIPTION
Sleeping the main thread for 500ms limits the rate so we don't surpass discord's rate of 5/second

closes #11